### PR TITLE
Support for diatrics/accents

### DIFF
--- a/lib/jsMegaHal.coffee
+++ b/lib/jsMegaHal.coffee
@@ -15,7 +15,7 @@ TODO more punctuation
 ###
 class jsMegaHal
 	#the regex to check the validity of a character
-	wordRegex: /[^a-zA-Z0-9,']+/
+	wordRegex: /[^a-zA-Z0-9,'\u00C0-\u017F]+/
 
 	#the regex to split sentences by -- remove all \r\n
 	sentenceRegex: /[!?\.]/


### PR DESCRIPTION
Modified the word separator regular expression to accommodate for diatrics and accents, making jsmegahal work better with foreign languages.